### PR TITLE
fix: Memory usage demo fix

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -63,6 +63,7 @@ export default defineNuxtConfig({
       'https://buttons.github.io/buttons.js'
     ],
     htmlAttrs: {
+      'lang': 'en',
       'data-theme': 'light' // https://daisyui.com/docs/default-themes
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -45,7 +45,9 @@
         <p class="text-primary">Memory usage</p>
 
         <div class="justify-center card-actions">
-        <memory-usage-demo/>
+           <client-only>
+	           <memory-usage-demo/>
+           </client-only>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Seems that <memory-usage-demo/> component is causing error during server rendering. Shouldn't be wrapped into 
`<client-only/>`


```
[Vue warn]: Unhandled error during execution of setup function 
  at <MemoryUsageDemo>
performance is not defined
  at Module.useMemory (file://./node_modules/@vueuse/core/index.mjs:2667:23)  
  at setup (file://./.nuxt/dist/server/server.mjs:3439:59)  
  at _sfc_main.setup (file://./.nuxt/dist/server/server.mjs:3468:23)  
  at callWithErrorHandling (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6650:22)  
  at setupStatefulComponent (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6276:29)  
  at setupComponent (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6232:11)  
  at renderComponentVNode (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:198:17)  
  at Module.ssrRenderComponent (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:623:12)  
  at _sfc_ssrRender (file://./.nuxt/dist/server/server.mjs:3396:31)  
  at renderComponentSubTree (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:263:13)

```